### PR TITLE
allow null sequence values

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,26 @@ return [
 ];
 ```
 
+You can allow/disallow null values by default in `config/eloquentsequencer.php`:
+
+```php
+return [
+    'allow_null' => true,
+];
+```
+
 ### Model configuration
 
 The `$sequenceable` attribute specifies the sequence column name for the model:
 
 ```php
 protected static $sequenceable = 'order';
+```
+
+The `$allowNull` attribute specifies if the sequence column will allow null values or not (this will take precedence over the default set in the config file). 
+
+```php
+protected static $allowNull = false;
 ```
 
 The relationship key(s) that will group the sequence items together:
@@ -43,6 +57,7 @@ protected static $sequenceableKeys = [
     'task_list_id',
 ];
 ```
+
 
 In the example above, a task list has many tasks.
 

--- a/config/config.php
+++ b/config/config.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
+    'allow_null'  => false,
     'column_name' => 'position',
 ];

--- a/tests/Unit/GetAllowNullMethodTest.php
+++ b/tests/Unit/GetAllowNullMethodTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Gurgentil\LaravelEloquentSequencer\Tests\Unit;
+
+use Facades\Gurgentil\LaravelEloquentSequencer\Tests\Factories\Factory;
+use Facades\Gurgentil\LaravelEloquentSequencer\Tests\Models\Item;
+use Gurgentil\LaravelEloquentSequencer\Tests\TestCase;
+
+class GetAllowNullMethodTest extends TestCase
+{
+    /** @test */
+    public function allow_null_may_be_set_in_the_configuration_file()
+    {
+        config(['eloquentsequencer.allow_null' => 'true']);
+
+        $group = Factory::of('Group')->create();
+
+        $this->assertEquals(true, Item::getAllowNull());
+    }
+}


### PR DESCRIPTION
I needed to be able to allow null values in a sequence. This PR accomplishes this by adding: 
- a configuration setting (for setting the default)
- a class property to set the value explicitly
- a getAllowNull() method to the trait
- a unit test for the new method