### PR TITLE
Exceed bounds config option

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -3,4 +3,5 @@
 return [
     'column_name' => 'position',
     'initial_value' => 1,
+    'exceed_bounds' => false,
 ];

--- a/src/Traits/Sequenceable.php
+++ b/src/Traits/Sequenceable.php
@@ -123,6 +123,10 @@ trait Sequenceable
      */
     protected function isNewSequenceValueOutOfBounds(): bool
     {
+        if(config('eloquentsequencer.exceed_bounds', false)) {
+            return false;
+        }
+
         $newValue = $this->getSequenceValue();
 
         return $newValue <= 0 || $newValue > $this->getNextSequenceValue();
@@ -135,6 +139,10 @@ trait Sequenceable
      */
     protected function isUpdatedSequenceValueOutOfBounds(): bool
     {
+        if(config('eloquentsequencer.exceed_bounds', false)) {
+            return false;
+        }
+
         $newValue = $this->getSequenceValue();
         $originalValue = $this->getOriginalSequenceValue();
 

--- a/tests/Unit/CreateObjectWithSequenceValueOutOfBoundsTest.php
+++ b/tests/Unit/CreateObjectWithSequenceValueOutOfBoundsTest.php
@@ -64,4 +64,19 @@ class CreateObjectWithSequenceValueOutOfBoundsTest extends TestCase
             'group_id' => $group->id,
         ]);
     }
+
+    /** @test */
+    public function it_bypasses_boundary_exception_when_configured_to()
+    {
+        config(['eloquentsequencer.exceed_bounds' => true]);
+
+        $group = Factory::of('Group')->create();
+
+        $item = Factory::of('Item')->create([
+            'position' => 9,
+            'group_id' => $group->id,
+        ]);
+
+        $this->assertEquals(9, $item->position);
+    }
 }

--- a/tests/Unit/UpdateObjectWithSequenceValueOutOfBoundsTest.php
+++ b/tests/Unit/UpdateObjectWithSequenceValueOutOfBoundsTest.php
@@ -105,4 +105,18 @@ class UpdateObjectWithSequenceValueOutOfBoundsText extends TestCase
 
         $item->update(['position' => 9]);
     }
+
+    /** @test */
+    public function it_bypasses_boundary_exception_when_configured_to()
+    {
+        config(['eloquentsequencer.exceed_bounds' => true]);
+
+        $group = Factory::of('Group')->create();
+
+        $item = Factory::of('Item')->create(['group_id' => $group->id]);
+
+        $item->update(['position' => 9]);
+
+        $this->assertEquals(9, $item->position);
+    }
 }


### PR DESCRIPTION
This PR adds a config option of `exceed_bounds => TRUE | FALSE`

The goal is to allow the trait to exceed the bounds of the min & max.

This allows package users to handle min / max scenarios on their own like: #8 

Without this option, the exception will overthrow any attempts to handle it.

For example, with your explanation / help, was able to set min max values like so:

```php
static::saving(function($model) {
    if($model->isDirty('order')) {
        $next = $model->getLastSequenceValue();
        if($model->order > $next) {
            $model->order = $next;
        } elseif($model->order <= 0) {
            $model->order = 1;
        }
    }
});
```
This only works if Im able to turn off the exception though. 🙏

Would be awesome if something like that was configurable also.

I can put -1 or 100000 and it will go to either 1  or the max number of models.

---

Ps: Also defaulted it to `false` incase anyone published the config so the update wont affect them

```php
config('eloquentsequencer.exceed_bounds', false);
```