### PR TITLE
Laravel 8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "illuminate/support": "^5.0|^6.0|^7.0"
+        "php": "^7.3",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.8|^4.0|^5.0",


### PR DESCRIPTION
Added `^8.0` version for `illuminate/support `.

Since Laravel 8 requires PHP 7.3 as minimum requirement and upgrading from 7.2 should be without conflicts, this also got increased.