### PR TITLE
fix: avoid false true when checking if propertyKeys exists

### DIFF
--- a/src/Traits/Sequenceable.php
+++ b/src/Traits/Sequenceable.php
@@ -409,8 +409,8 @@ trait Sequenceable
      */
     protected function getSequenceKeys(): array
     {
-        return (array) property_exists(static::class, 'sequenceableKeys')
-            ? static::$sequenceableKeys
+        return property_exists(static::class, 'sequenceableKeys')
+            ? (array) static::$sequenceableKeys
             : [];
     }
 


### PR DESCRIPTION
Casting `property_exists(static::class, 'sequenceableKeys')` to an array (`[true]` or `[false]`) is causing the conditional to always be truthy.