### PR TITLE
fix: prevent endless loop on incrementOrDecrement in laravel 8

### DIFF
--- a/src/Traits/Sequenceable.php
+++ b/src/Traits/Sequenceable.php
@@ -240,7 +240,8 @@ trait Sequenceable
                 ->where('id', '!=', $model->id)
                 ->filter(function ($sequenceModel) use ($model) {
                     return $sequenceModel->isAffectedByRepositioningOf($model);
-                });
+                })
+                ->each->withoutSequencing();
 
             if ($model->isMovingUpInSequence()) {
                 static::decrementSequenceValues($modelsToUpdate);


### PR DESCRIPTION
In Laravel 8, `Model::incrementOrDecrement()` now dispatches the `updating` Eloquent event. This currently causes an endless loop when updating the affected sequenceables.