### PR TITLE
fix: handle issues with original values

### DIFF
--- a/src/Traits/Sequenceable.php
+++ b/src/Traits/Sequenceable.php
@@ -261,7 +261,7 @@ trait Sequenceable
      */
     protected function isMovingUpInSequence(): bool
     {
-        $originalValue = $originalValue ?? $this->getOriginalSequenceValue();
+        $originalValue = $this->getOriginalSequenceValue();
 
         return $originalValue && $originalValue < $this->getSequenceValue();
     }

--- a/src/Traits/Sequenceable.php
+++ b/src/Traits/Sequenceable.php
@@ -263,7 +263,7 @@ trait Sequenceable
     {
         $originalValue = $this->getOriginalSequenceValue();
 
-        return !is_null($originalValue) && $originalValue < $this->getSequenceValue();
+        return ! is_null($originalValue) && $originalValue < $this->getSequenceValue();
     }
 
     /**
@@ -275,7 +275,7 @@ trait Sequenceable
     {
         $originalValue = $this->getOriginalSequenceValue();
 
-        return !is_null($originalValue) && $originalValue > $this->getSequenceValue();
+        return ! is_null($originalValue) && $originalValue > $this->getSequenceValue();
     }
 
     /**

--- a/src/Traits/Sequenceable.php
+++ b/src/Traits/Sequenceable.php
@@ -444,4 +444,13 @@ trait Sequenceable
      * @return bool
      */
     abstract public function isClean($attributes = null);
+
+    /**
+     * Get the model's original attribute values.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed|array
+     */
+    abstract public function getOriginal($key = null, $default = null);
 }

--- a/src/Traits/Sequenceable.php
+++ b/src/Traits/Sequenceable.php
@@ -263,7 +263,7 @@ trait Sequenceable
     {
         $originalValue = $this->getOriginalSequenceValue();
 
-        return $originalValue && $originalValue < $this->getSequenceValue();
+        return !is_null($originalValue) && $originalValue < $this->getSequenceValue();
     }
 
     /**
@@ -275,7 +275,7 @@ trait Sequenceable
     {
         $originalValue = $this->getOriginalSequenceValue();
 
-        return $originalValue && $originalValue > $this->getSequenceValue();
+        return !is_null($originalValue) && $originalValue > $this->getSequenceValue();
     }
 
     /**


### PR DESCRIPTION
- remove invalid `isset` check for `$originalValue` when it has never been set
- replace loose comparison for `$originalValue` with `!is_null` check
- add `getOriginal` abstract declaration