### PR TITLE
Support withoutSequencing() on create

### DIFF
--- a/src/Traits/Sequenceable.php
+++ b/src/Traits/Sequenceable.php
@@ -65,6 +65,12 @@ trait Sequenceable
             return;
         }
 
+        if (! $this->shouldBeSequenced) {
+            $this->shouldBeSequenced = true;
+
+            return;
+        }
+        
         if (is_null($value)) {
             $this->{static::getSequenceColumnName()} = $this->getNextSequenceValue();
         }


### PR DESCRIPTION
Currently `withoutSequencing()` works only on updates. This will allow `withoutSequencing()` on creation as well.