### PR TITLE
Fix command in documentation for vendor publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require gurgentil/laravel-eloquent-sequencer
 To publish the configuration file run:
 
 ```bash
-php artisan vendor:publish --provider="Gurgentil\LaravelEloquentSequencer\LaravelEloquentSequencerServiceProvider"
+php artisan vendor:publish --provider="Gurgentil\LaravelEloquentSequencer\ServiceProvider"
 ```
 
 ### Configuration parameters


### PR DESCRIPTION
Correct the ServiceProvider class reference in the command to publish Laravel Eloquent Sequencer configuration.