### PR TITLE
Add position manipulation methods and tests to sequencer

### DIFF
--- a/src/Traits/Sequenceable.php
+++ b/src/Traits/Sequenceable.php
@@ -280,6 +280,43 @@ trait Sequenceable
     }
 
     /**
+     * Move the position of the model up.
+     *
+     *
+     * @param int $by The amount by which the position should be moved up
+     *
+     * @return void
+     */
+    public function moveUp(int $by = 1)
+    {
+        $this->decrement(static::getSequenceColumnName(), $by);
+    }
+
+    /**
+     * Move the position of the model down.
+     *
+     * @param int $by The amount by which the position should be moved down
+     *
+     * @return void
+     */
+    public function moveDown(int $by = 1)
+    {
+        $this->increment(static::getSequenceColumnName(), $by);
+    }
+
+    /**
+     * Move a model to a new position.
+     *
+     * @param int $position The new position for the model.
+     *
+     * @return void
+     */
+    public function moveToPosition(int $position)
+    {
+        $this->update([static::getSequenceColumnName() => $position]);
+    }
+
+    /**
      * Indicate if model is affected by the repositioning of another model in the sequence.
      *
      * @param Model $model

--- a/tests/UpdateSequenceableTest.php
+++ b/tests/UpdateSequenceableTest.php
@@ -302,4 +302,148 @@ class UpdateSequenceableTest extends TestCase
 
         $item->update(['position' => 9]);
     }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function move_up_works_like_model_update_on_position_decremented_by_one()
+    {
+        $sequence = $this->createSequence();
+
+        $firstItem = $this->createSequenceable($sequence);
+        $secondItem = $this->createSequenceable($sequence);
+        $thirdItem = $this->createSequenceable($sequence);
+        $fourthItem = $this->createSequenceable($sequence);
+        $fifthItem = $this->createSequenceable($sequence);
+
+        $fourthItem->moveUp();
+
+        $this->assertSequenced([
+            $firstItem,
+            $secondItem,
+            $fourthItem,
+            $thirdItem,
+            $fifthItem,
+        ]);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function move_down_works_like_model_update_on_position_incremented_by_one()
+    {
+        $sequence = $this->createSequence();
+
+        $firstItem = $this->createSequenceable($sequence);
+        $secondItem = $this->createSequenceable($sequence);
+        $thirdItem = $this->createSequenceable($sequence);
+        $fourthItem = $this->createSequenceable($sequence);
+        $fifthItem = $this->createSequenceable($sequence);
+
+        $fourthItem->moveDown();
+
+        $this->assertSequenced([
+            $firstItem,
+            $secondItem,
+            $thirdItem,
+            $fifthItem,
+            $fourthItem,
+        ]);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function move_up_by_amount_works_like_model_update_on_position_decremented_by_one()
+    {
+        $sequence = $this->createSequence();
+
+        $firstItem = $this->createSequenceable($sequence);
+        $secondItem = $this->createSequenceable($sequence);
+        $thirdItem = $this->createSequenceable($sequence);
+        $fourthItem = $this->createSequenceable($sequence);
+        $fifthItem = $this->createSequenceable($sequence);
+
+        $fourthItem->moveUp(2);
+
+        $this->assertSequenced([
+            $firstItem,
+            $fourthItem,
+            $secondItem,
+            $thirdItem,
+            $fifthItem,
+        ]);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function move_down_by_amount_works_like_model_update_on_position_incremented_by_one()
+    {
+        $sequence = $this->createSequence();
+
+        $firstItem = $this->createSequenceable($sequence);
+        $secondItem = $this->createSequenceable($sequence);
+        $thirdItem = $this->createSequenceable($sequence);
+        $fourthItem = $this->createSequenceable($sequence);
+        $fifthItem = $this->createSequenceable($sequence);
+
+        $thirdItem->moveDown(2);
+
+        $this->assertSequenced([
+            $firstItem,
+            $secondItem,
+            $fourthItem,
+            $fifthItem,
+            $thirdItem,
+        ]);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function move_to_position_works_like_model_update_on_position_incremented_by_one()
+    {
+        $sequence = $this->createSequence();
+
+        $firstItem = $this->createSequenceable($sequence);
+        $secondItem = $this->createSequenceable($sequence);
+        $thirdItem = $this->createSequenceable($sequence);
+        $fourthItem = $this->createSequenceable($sequence);
+        $fifthItem = $this->createSequenceable($sequence);
+
+        $fourthItem->moveToPosition(1);
+
+        $this->assertSequenced([
+            $fourthItem,
+            $firstItem,
+            $secondItem,
+            $thirdItem,
+            $fifthItem,
+        ]);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function move_up_to_position_out_of_bounds_fails()
+    {
+        $sequence = $this->createSequence();
+
+        $firstItem = $this->createSequenceable($sequence);
+        $secondItem = $this->createSequenceable($sequence);
+        $thirdItem = $this->createSequenceable($sequence);
+        $fourthItem = $this->createSequenceable($sequence);
+        $fifthItem = $this->createSequenceable($sequence);
+
+        $this->expectException(SequenceValueOutOfBoundsException::class);
+
+        $firstItem->moveUp();
+    }
 }


### PR DESCRIPTION
Implemented and tested moveUp, moveDown, and moveToPosition methods in the sequencer model, enhancing control over item positioning within sequences. These methods facilitate direct incrementing, decrementing, or setting the position of a model, with accompanying tests ensuring the functionality and stability of list re-sequencing operations.